### PR TITLE
17.SOLID.md: Fix Open/Closed Principle examples

### DIFF
--- a/17.SOLID.md
+++ b/17.SOLID.md
@@ -126,7 +126,7 @@ This means that the behavior of a module/class/function can be extended without 
 
 Let's consider an example of a `TaxCalculator` class that calculates tax based on the type of product. Initially, the class is not following `OCP`, because **_every time a new tax type is introduced, the class has to be modified._**
 
-#### Correct Example
+#### Incorrect Example
 
 ```python
 class TaxCalculator:
@@ -138,7 +138,7 @@ class TaxCalculator:
         # More conditions for other product types
 ```
 
-#### Incorrect Example
+#### Correct Example
 
 To follow the `OCP`, we can define a generic `TaxCalculator` class and then extend it for each specific tax type.
 


### PR DESCRIPTION
If I understand correctly, the first example should be the Incorrect one, since we don't want to put everything under one function. The second example is correct, since we are only open for extending our class